### PR TITLE
Enable local startup on JDK 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <java.version>1.8</java.version>
+        <lombok.version>1.18.34</lombok.version>
         <start-class>com.treeliked.darkme2.Darkme2Application</start-class>
     </properties>
 

--- a/src/main/java/com/treeliked/darkme2/Darkme2Application.java
+++ b/src/main/java/com/treeliked/darkme2/Darkme2Application.java
@@ -1,16 +1,8 @@
 package com.treeliked.darkme2;
 
-import org.apache.catalina.Context;
-import org.apache.catalina.connector.Connector;
-import org.apache.tomcat.util.descriptor.web.SecurityCollection;
-import org.apache.tomcat.util.descriptor.web.SecurityConstraint;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.Banner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
-import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
-import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
@@ -22,63 +14,9 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 public class Darkme2Application {
 
-    private int httpPort = 80;
-
-    @Value("${server.port}")
-    private int httpsPort;
-
     public static void main(String[] args) {
         SpringApplication app = new SpringApplication(Darkme2Application.class);
         app.setBannerMode(Banner.Mode.OFF);
         app.run(args);
     }
-
-    /**
-     * it's for set http url auto change to https
-     */
-     @Bean
-     public ServletWebServerFactory servletContainer() {
-         TomcatServletWebServerFactory tomcat = new TomcatServletWebServerFactory() {
-             @Override
-             protected void postProcessContext(Context context) {
-                 SecurityConstraint securityConstraint = new SecurityConstraint();
-                 securityConstraint.setUserConstraint("CONFIDENTIAL");
-                 SecurityCollection collection = new SecurityCollection();
-                 collection.addPattern("/*");
-                 securityConstraint.addCollection(collection);
-                 context.addConstraint(securityConstraint);
-             }
-         };
-         tomcat.addAdditionalTomcatConnectors(redirectConnector());
-         return tomcat;
-     }
-
-     private Connector redirectConnector() {
-         Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
-         connector.setScheme("http");
-         connector.setPort(httpPort);
-         connector.setSecure(false);
-         connector.setRedirectPort(httpsPort);
-         return connector;
-     }
-
-
-    //@Bean
-    //public ServletWebServerFactory servletContainer() {
-    //    TomcatServletWebServerFactory tomcat = new TomcatServletWebServerFactory();
-    //    tomcat.addAdditionalTomcatConnectors(createHTTPConnector());
-    //    return tomcat;
-    //}
-    //
-    //private Connector createHTTPConnector() {
-    //    Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
-    //    connector.setScheme("http");
-    //    connector.setSecure(false);
-    //    // http 端口
-    //    connector.setPort(30001);
-    //    //https 端口
-    //    connector.setRedirectPort(8080);
-    //    return connector;
-    //}
 }
-

--- a/src/main/java/com/treeliked/darkme2/config/TomcatHttpsRedirectConfig.java
+++ b/src/main/java/com/treeliked/darkme2/config/TomcatHttpsRedirectConfig.java
@@ -1,0 +1,51 @@
+package com.treeliked.darkme2.config;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.connector.Connector;
+import org.apache.tomcat.util.descriptor.web.SecurityCollection;
+import org.apache.tomcat.util.descriptor.web.SecurityConstraint;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * 生产环境 HTTP 自动跳转 HTTPS
+ */
+@Configuration
+@Profile("!local")
+public class TomcatHttpsRedirectConfig {
+
+    private final int httpPort = 80;
+
+    @Value("${server.port}")
+    private int httpsPort;
+
+    @Bean
+    public ServletWebServerFactory servletContainer() {
+        TomcatServletWebServerFactory tomcat = new TomcatServletWebServerFactory() {
+            @Override
+            protected void postProcessContext(Context context) {
+                SecurityConstraint securityConstraint = new SecurityConstraint();
+                securityConstraint.setUserConstraint("CONFIDENTIAL");
+                SecurityCollection collection = new SecurityCollection();
+                collection.addPattern("/*");
+                securityConstraint.addCollection(collection);
+                context.addConstraint(securityConstraint);
+            }
+        };
+        tomcat.addAdditionalTomcatConnectors(redirectConnector());
+        return tomcat;
+    }
+
+    private Connector redirectConnector() {
+        Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
+        connector.setScheme("http");
+        connector.setPort(httpPort);
+        connector.setSecure(false);
+        connector.setRedirectPort(httpsPort);
+        return connector;
+    }
+}

--- a/src/main/java/com/treeliked/darkme2/util/DownloadUtils.java
+++ b/src/main/java/com/treeliked/darkme2/util/DownloadUtils.java
@@ -1,12 +1,11 @@
 package com.treeliked.darkme2.util;
 
 
-import sun.misc.BASE64Encoder;
-
 import javax.servlet.http.HttpServletResponse;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  * 工具类
@@ -40,8 +39,7 @@ public class DownloadUtils {
             filename = filename.replace("+", " ");
         } else if (agent.contains(BROWSER_FIREFOX)) {
             // 火狐浏览器
-            BASE64Encoder base64Encoder = new BASE64Encoder();
-            filename = "=?utf-8?B?" + base64Encoder.encode(filename.getBytes(StandardCharsets.UTF_8)) + "?=";
+            filename = "=?utf-8?B?" + Base64.getEncoder().encodeToString(filename.getBytes(StandardCharsets.UTF_8)) + "?=";
         } else {
             // 其它浏览器
             filename = URLEncoder.encode(filename, "utf-8");

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,12 @@
+server:
+  port: 8080
+  ssl:
+    enabled: false
+
+spring:
+  thymeleaf:
+    cache: false
+
+logging:
+  level:
+    com.treeliked.darkme2: info


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the project runnable in modern development environments (JDK 21) with a dedicated local profile.

## Changes

- Upgrade Lombok to 1.18.34 for JDK 21 compatibility
- Replace deprecated `sun.misc.BASE64Encoder` with `java.util.Base64`
- Add `application-local.yml` profile: HTTP on port 8080, SSL disabled, Thymeleaf cache off
- Move production HTTPS redirect (port 80 → HTTPS) into `TomcatHttpsRedirectConfig`, active only when **not** using the `local` profile

## How to run locally

```bash
./mvnw package -DskipTests
java -jar target/darkme2-0.0.1-SNAPSHOT.jar --spring.profiles.active=local
```

Then open http://localhost:8080/
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aaafb943-4214-4ccd-b10a-070d81d98daf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aaafb943-4214-4ccd-b10a-070d81d98daf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

